### PR TITLE
Incorporated Protocol V3.3 For Firmware 1.0.5 Upwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,7 @@ Please note, these smart plugs and this script do not hold power usage data in m
 
 
 ## Acknowledgements
-
 * https://github.com/clach04/python-tuya
+
+## Contributers
+* Phill Healey ([codeclinic](https://github.com/codeclinic)) - Integration for firmwares (1.0.5+) / protocol v3.3 & commandline arguments.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PowerMonitor -(Tuya Power Stats)
+# PowerMonitor (Tuya Power Stats)
 Monitor power usage through WiFi Smart Plug
 
 This script will will poll [Tuya](https://en.tuya.com/) campatible Smart Plugs for state (on/off), current (mA), voltage (V), and power (wattage).  

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ eg:
 ```
 
 ```
- #Devices with older firmware (1.0.4 and below)
+ #Devices with newer firmware (1.0.5 and above)
  python plugpower.py 01234567890 10.0.1.99 0123456789abcdef 3.3
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker run -e PLUGID='01234567891234567890' -e PLUGIP="10.0.1.x" -e PLUGKEY="012
 docker run -e PLUGID='01234567891234567890' -e PLUGIP="10.0.1.x" -e PLUGKEY="0123456789abcdef" -e PLUGINVERS="3.3" -e powermonitor
 ```
 
-## Setup: Option 1 - Manually (Tested on RaspberryPi):  
+## Setup: Option 2 - Manually (Tested on RaspberryPi):  
 
 The script does not need docker but it does require the pycrypto python library. Follow these steps to set it up and run the script:
 

--- a/README.md
+++ b/README.md
@@ -7,61 +7,67 @@ This project is based on the python pytuya library to poll [Tuya](https://en.tuy
 
 REQUIRED: IP address and Device ID of  smart plug.
 
-## Setup
+## Preparation
 1. Download the Smart Life - Smart Living app for iPhone or Android. Pair with your smart plug (this is important as you cannot monitor a plug that has not been paired).  
 	* https://itunes.apple.com/us/app/smart-life-smart-living/id1115101477?mt=8
 	* https://play.google.com/store/apps/details?id=com.tuya.smartlife&hl=en
-2. Device ID - Inside the app, select the plug you wish to monitor, select the three dot top right and "Device Info".  The page should display "Device ID" which the script will use to poll the plug.
-3. IP Address - You will need to determine what IP address your network assigned to the Smart Plug - this is more difficult but tooks like `arp-scan` can help identify devices on your network.  WiFi Routers often have a list of devices connected as well.  Look for devices with a name like "ESP_xxxxxx".
+2. Device ID - Inside the app, select the plug you wish to monitor, select the 3 dots(Jinvoo) or the edit/pencil icon(Tuya & SmartLife) in the top right and then "Device Info".  The page should display "Device ID" which the script will use to poll the plug. It's also worth noting the MAC address of the device as it can come in handy in step 3.
+3. IP Address - If your router displays a list of all the devices that are connected to it, you can search for MAC address of the device. This is often the quickest way to locate your device IP.
 
-## Run
-You can use the following command to pull and run the powermonitor docker container.  You will need to replace the enviroinmental values to your device's IP and ID values.
+Alternatively, you will need to manually determine what IP address your network assigned to the Smart Plug - this is more difficult but it looks like `arp-scan` can help identify devices on your network.  WiFi Routers often have a list of devices connected as well. Look for devices with a name like "ESP_xxxxxx". Many modern routers allow you to set the hostname of connected devices to something more memorable, once you have located it.
 
-```
-# run powermonitor container - replace with device ID and IP 
-docker run -e PLUGID='01234567891234567890' -e PLUGIP="10.0.1.x" jasonacox/powermonitor
-```
+4. Firmware Version - Devices with newer firmware (1.0.5 and above) are typically using a different protocol. These devices need to be communicated with using encryption and the resultant data is packaged slightly differently. It's a good idea therefore to check the Firmware version of the device(s) too. Again in the Tuya/SmartLife/Jinvoo app there will be a device option "Check for Firmware Upgrade" or similar. Open this option and take note of the Wi-Fi Module & MCU Module numbers. These are usually the same.
 
-Docker Hub: https://hub.docker.com/r/jasonacox/powermonitor
+5. Device Key - If your device is running Firmware 1.0.5 or above, you will need to obtain the Device Key. This is used to connect with the device  decrypt the power consumption data. For details on how to do this, see point 2: https://github.com/clach04/python-tuya/wiki 
 
-## Build and Run
 
-**OPTION 1**: Build a docker container using `Dockerfile`
+## Setup: Option 1 - Docker
+
+Build a docker container using `Dockerfile` or get it at Docker Hub: https://hub.docker.com/r/jasonacox/powermonitor
 ```
 # build powermonitor container
 docker build -t powermonitor .
 
+# Devices with older firmware (1.0.4 and below)
 # run powermonitor container - replace with device ID and IP 
-docker run -e PLUGID='01234567891234567890' -e PLUGIP="10.0.1.x" -e PLUGKEY="0123456789abcdef" powermonitor
+docker run -e PLUGID='01234567891234567890' -e PLUGIP="10.0.1.x" -e PLUGKEY="0123456789abcdef" -e PLUGVERS=" " -e powermonitor
+
+# Devices with newer firmware (1.0.5 and above)
+# run powermonitor container - replace with device ID and IP 
+docker run -e PLUGID='01234567891234567890' -e PLUGIP="10.0.1.x" -e PLUGKEY="0123456789abcdef" -e PLUGINVERS="3.3" -e powermonitor
 ```
 
-**OPTION 2**: Run Manually:  
+## Setup: Option 1 - Manually (Tested on RaspberryPi):  
 
-The script does not need docker but it does require the pycrypto python library. Follow these steps to set it up and run the `plugpower.py` script:
+The script does not need docker but it does require the pycrypto python library. Follow these steps to set it up and run the script:
 
-1. Edit `plugpower.py` and add your Device ID and IP Address.  Alternatively, you can use envrionment variables instead (see `test.sh`).
-2. Install pip and python libraries if you haven't already:
+1. Install pip and python libraries if you haven't already:
 
 ```
-# Tested on RaspberryPi 
-
  sudo apt-get install python-crypto python-pip		
  pip install pycrypto
  pip install Crypto		# some systems will need this
  pip install pyaes		# some systems will need this
 ```
-3. Run the python script:
-```
- python plugpower.py
 
+2. Run the python script:
+```
+ #Devices with older firmware (1.0.4 and below)
+ python plugpower.py 01234567890 10.0.1.99 0123456789abcdef
+```
+
+```
+ #Devices with older firmware (1.0.4 and below)
+ python plugpower.py 01234567890 10.0.1.99 0123456789abcdef 3.3
 ```
 
 ## JSON Output Script
 The `plugjson.py` script works the same as `plugpower.py` but produces the data in JSON output with a datetime stamp.  This makes it easier to feed into other systems for recording, alerting or graphing.
 
 ## Example Output
+### Docker
 ```
-$ docker run -e PLUGID='01234567891234567890' -e PLUGIP="10.0.1.99" -e PLUGKEY="0123456789abcdef" jasonacox/powermonitor
+$ docker run -e PLUGID='01234567891234567890' -e PLUGIP="10.0.1.99" -e PLUGKEY="0123456789abcdef" -e PLUGINVERS=" " -e jasonacox/powermonitor
 
 Polling Device 01234567891234567890 at 10.0.1.99 with key 0123456789abcde1
 Dictionary {'devId': '01234567891234567890', 'dps': {'1': True, '2': 0, '4': 69, '5': 12, '6': 1181}}
@@ -70,8 +76,11 @@ Power (W): 1.200000
 Current (mA): 69.000000
 Voltage (V): 118.100000
 Projected usage (kWh):  Day: 0.028800  Week: 0.201600  Month: 0.873600
+```
 
-$ bash test.sh 
+### Command Line / Bash Script
+```
+$ bash test.sh 01234567890 10.0.1.99 0123456789abcdef 3.1
 JSON Output - plugjson.py:
 { "datetime": "2019-08-31T07:20:59Z", "switch": "True", "power": "1.2", "current": "70.0", "voltage": "122.1" }
 
@@ -83,14 +92,16 @@ Power (W): 1.300000
 Current (mA): 70.000000
 Voltage (V): 122.000000
 Projected usage (kWh):  Day: 0.031200  Week: 0.218400  Month: 0.946400
-
 ```
+
 Please note, these smart plugs and this script do not hold power usage data in memory so the "Projected usage" reported is an estimate based on current power readings and assumed steady state over time. 
 
 ## Example Products 
 * TanTan Smart Plug Mini Wi-Fi Enabled Outlet with Energy Monitoring - https://www.amazon.com/gp/product/B075Z17987/ref=oh_aui_detailpage_o03_s00?ie=UTF8&psc=1
 * SKYROKU SM-PW701U Wi-Fi Plug Smart Plug - see https://wikidevi.com/wiki/Xenon_SM-PW701U
 * Wuudi SM-S0301-US - WIFI Smart Power Socket Multi Plug with 4 AC Outlets and 4 USB Charging
+* Gosund SP1 - WiFi High Amp RatedSmart Power Socket (eu) using 3.3 Protocol - see https://www.amazon.de/Steckdose-Stromverbrauch-Funktion-Fernsteurung-Netzwerk/dp/B07B911Y6V
+
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ REQUIRED: IP address and Device ID of  smart plug.
 	* https://itunes.apple.com/us/app/smart-life-smart-living/id1115101477?mt=8
 	* https://play.google.com/store/apps/details?id=com.tuya.smartlife&hl=en
 2. Device ID - Inside the app, select the plug you wish to monitor, select the 3 dots(Jinvoo) or the edit/pencil icon(Tuya & SmartLife) in the top right and then "Device Info".  The page should display "Device ID" which the script will use to poll the plug. It's also worth noting the MAC address of the device as it can come in handy in step 3.
-3. IP Address - If your router displays a list of all the devices that are connected to it, you can search for MAC address of the device. This is often the quickest way to locate your device IP.
+3. IP Address - If your router displays a list of all the devices that are connected to it, you can search for the MAC address of the device. This is often the quickest way to locate your device IP.
 
-Alternatively, you will need to manually determine what IP address your network assigned to the Smart Plug - this is more difficult but it looks like `arp-scan` can help identify devices on your network.  WiFi Routers often have a list of devices connected as well. Look for devices with a name like "ESP_xxxxxx". Many modern routers allow you to set the hostname of connected devices to something more memorable, once you have located it.
+	Alternatively, you will need to manually determine what IP address your network assigned to the Smart Plug - this is more difficult but it looks like `arp-scan` can help identify devices on your network.  WiFi Routers often have a list of devices connected as well. Look for devices with a name like "ESP_xxxxxx". Many modern routers allow you to set the hostname of connected devices to something more memorable, once you have located it.
 
 4. Firmware Version - Devices with newer firmware (1.0.5 and above) are typically using a different protocol. These devices need to be communicated with using encryption and the resultant data is packaged slightly differently. It's a good idea therefore to check the Firmware version of the device(s) too. Again in the Tuya/SmartLife/Jinvoo app there will be a device option "Check for Firmware Upgrade" or similar. Open this option and take note of the Wi-Fi Module & MCU Module numbers. These are usually the same.
 
@@ -51,6 +51,11 @@ The script does not need docker but it does require the pycrypto python library.
 ```
 
 2. Run the python script:
+```
+ #Devices with older firmware (1.0.4 and below)
+ python plugpower.py {DEVICEID} {DEVICEIP} {DEVICEKEY} {DEVICEVERS [optional]}
+```
+eg:
 ```
  #Devices with older firmware (1.0.4 and below)
  python plugpower.py 01234567890 10.0.1.99 0123456789abcdef

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PowerMonitor
+# PowerMonitor -(Tuya Power Stats)
 Monitor power usage through WiFi Smart Plug
 
 This script will will poll [Tuya](https://en.tuya.com/) campatible Smart Plugs for state (on/off), current (mA), voltage (V), and power (wattage).  

--- a/plugpower.py
+++ b/plugpower.py
@@ -6,42 +6,65 @@ import pytuya
 from time import sleep
 import datetime
 import os
+import sys
 
 # Device Info - EDIT THIS
-DEVICEID="01234567891234567890"
-DEVICEIP="10.1.1.1"
-DEVICEKEY="0123456789abcdef"
+DEVICEID=sys.argv[1]
+DEVICEIP=sys.argv[2]
+DEVICEKEY=sys.argv[3]
+DEVICEVERS=sys.argv[4] if len(sys.argv) >= 5 else '3.1'
 
 PLUGID=os.getenv('PLUGID', DEVICEID)
 PLUGIP=os.getenv('PLUGIP', DEVICEIP)
 PLUGKEY=os.getenv('PLUGKEY', DEVICEKEY)
+PLUGVERS=os.getenv('PLUGVERS', DEVICEVERS)
 
 # how my times to try to probe plug before giving up
 RETRY=5
 
-def deviceInfo( deviceid, ip, key ):
+def deviceInfo( deviceid, ip, key, vers ):
     watchdog = 0
     while True:
         try:
             d = pytuya.OutletDevice(deviceid, ip, key)
+            if vers == '3.3':
+                d.set_version(3.3)
+
             data = d.status()
             if(d):
                 print('Dictionary %r' % data)
                 print('Switch On: %r' % data['dps']['1'])
-                if '5' in data['dps'].keys():
-                    w = (float(data['dps']['5'])/10.0)
-                    mA = float(data['dps']['4'])
-                    V = (float(data['dps']['6'])/10.0)
-                    day = (w/1000.0)*24
-                    week = 7.0 * day
-                    month = (week * 52.0)/12.0
-                    print('Power (W): %f' % w)
-                    print('Current (mA): %f' % mA)
-                    print('Voltage (V): %f' % V)
-                    print('Projected usage (kWh):  Day: %f  Week: %f  Month: %f' % (day, week, month))
-                    return(float(data['dps']['5'])/10.0)
+
+                if vers == '3.3':
+                    if '19' in data['dps'].keys():
+                        w = (float(data['dps']['19'])/10.0)
+                        mA = float(data['dps']['18'])
+                        V = (float(data['dps']['20'])/10.0)
+                        day = (w/1000.0)*24
+                        week = 7.0 * day
+                        month = (week * 52.0)/12.0
+                        print('Power (W): %f' % w)
+                        print('Current (mA): %f' % mA)
+                        print('Voltage (V): %f' % V)
+                        print('Projected usage (kWh):  Day: %f  Week: %f  Month: %f' % (day, week, month))
+                        return(float(data['dps']['5'])/10.0)
+                    else:
+                        return(0.0)
                 else:
-                    return(0.0)
+                    if '5' in data['dps'].keys():
+                        w = (float(data['dps']['5'])/10.0)
+                        mA = float(data['dps']['4'])
+                        V = (float(data['dps']['6'])/10.0)
+                        day = (w/1000.0)*24
+                        week = 7.0 * day
+                        month = (week * 52.0)/12.0
+                        print('Power (W): %f' % w)
+                        print('Current (mA): %f' % mA)
+                        print('Voltage (V): %f' % V)
+                        print('Projected usage (kWh):  Day: %f  Week: %f  Month: %f' % (day, week, month))
+                        return(float(data['dps']['5'])/10.0)
+                    else:
+                        return(0.0)
             else:
                 return(0.0)
             break
@@ -55,8 +78,8 @@ def deviceInfo( deviceid, ip, key ):
             sleep(2)
 
 
-print("Polling Device %s at %s with key %s" % (PLUGID,PLUGIP,PLUGKEY))
+print("Polling Device %s at %s with key %s and protocol version %s" % (PLUGID,PLUGIP,PLUGKEY,PLUGVERS))
 
-devicepower = deviceInfo(PLUGID,PLUGIP,PLUGKEY)
+devicepower = deviceInfo(PLUGID,PLUGIP,PLUGKEY,PLUGVERS)
 
 

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-export PLUGID='01234567891234567890' 
-export PLUGIP="10.1.1.1" 
-export PLUGKEY="0123456789abcdef"
+export PLUGID=$0 
+export PLUGIP=$1
+export PLUGKEY=$2
+export PLUGVERS=${3:-'3.1'}
+
 echo "JSON Output - plugjson.py:"
 ./plugjson.py
 echo


### PR DESCRIPTION
This adds compatibility for the new v3.3 protocol devices using firmwares 1.0.5. and upwards.

Also added the ability to send key, device id, etc as script arguments to the python & test.sh files so that they aren't coded in the script. This makes it possible to use the same scripts for multiple devices via cron etc. 
Note, I don't use docker so not sure how it works with the env variables but guessed at them based on the existing readme. Let me know if these aren't correct, or feel free to update these bits.

Also, updated the readme to make it a bit easier to understand for none docker implementations.